### PR TITLE
wait 2 seconds between notifications

### DIFF
--- a/yknotify.sh
+++ b/yknotify.sh
@@ -1,23 +1,31 @@
 #!/bin/bash
 
+# List of sounds: https://apple.stackexchange.com/a/479714
+
 # Adjust as needed
-YKNTFY_BIN="Users/<USER>/go/bin/yknotify"
+YKNTFY_BIN="/Users/<USER>/go/bin/yknotify"
 
 # brew install terminal-notifier
 TERM_NTFY_BIN="/opt/homebrew/bin/terminal-notifier"
 
 # Stream yknotify output and process each line
-"$YKNTFY_BIN" | while IFS= read -r line; do
+LAST_NTFY=0
+while IFS= read -r line; do
 
-    message=$(echo "$line" | jq -r '.type')
+    # 2-second delay between notifications
+    NOW="$(date +%s)"
+    if [[ "$NOW" -le "$((LAST_NTFY + 2))" ]]; then
+        continue
+    fi
+    LAST_NTFY="$NOW"
 
     # Send notification using terminal-notifier
+    message="$(echo "$line" | jq -r '.type')"
     if [[ -x "$TERM_NTFY_BIN" ]]; then
-        # List of sounds: https://apple.stackexchange.com/a/479714
-        # Use "legacy name" as noted here: https://github.com/julienXX/terminal-notifier/issues/283#issuecomment-832569237
         "$TERM_NTFY_BIN" -title "yknotify" -message "$message" -sound Submarine
     else
         # Fallback to AppleScript if terminal-notifier is not installed
         osascript -e "display notification \"$message\" with title \"yknotify\""
     fi
-done
+
+done < <("$YKNTFY_BIN")


### PR DESCRIPTION
terminal-notifier notifications tend to "bunch up" with irregular timing without a fixed delay between them. this change regulates that by waiting 2 seconds between notifications.