### PR TITLE
Tighten log stream predicate to reduce CPU usage

### DIFF
--- a/yknotify.go
+++ b/yknotify.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-const defaultPredicate = `(senderImagePath CONTAINS "HID") OR (subsystem CONTAINS "CryptoTokenKit")`
+const defaultPredicate = `(processImagePath == "/kernel" AND senderImagePath ENDSWITH "IOHIDFamily") OR (subsystem CONTAINS "CryptoTokenKit")`
 
 var (
 	predicate = flag.String("predicate", defaultPredicate, "NSPredicate filter for log stream")


### PR DESCRIPTION
Extends #8 to also address `log stream` CPU usage.

### Problem

PR #8 added predicate filtering which reduced `yknotify` CPU from 27% to 0.02%, but `log stream` itself still consumed ~92% CPU. The predicate `senderImagePath CONTAINS "HID"` matches many userspace HID plugins (ColourSensorFilterPlugin, UniversalControlServiceFilter, etc.) that are unrelated to YubiKey.

### Solution

Tighten the predicate to only match kernel-level IOHIDFamily events:
```diff
-const defaultPredicate = `(senderImagePath CONTAINS "HID") OR (subsystem CONTAINS "CryptoTokenKit")`
+const defaultPredicate = `(processImagePath == "/kernel" AND senderImagePath ENDSWITH "IOHIDFamily") OR (subsystem CONTAINS "CryptoTokenKit")`
```

All YubiKey FIDO2 events have `processImagePath == "/kernel"`, so this filters out the userspace noise.

### Before/After

| Process | Before | After |
|---------|--------|-------|
| `yknotify` | 0.02% | 0.02% |
| `log stream` | ~97% | ~0.18% |